### PR TITLE
Leave ca-certificates installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y git \
     && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
     && chmod +x /usr/local/bin/gosu \
     && gosu nobody true \
-    && apt-get purge -y --auto-remove ca-certificates wget
+    && apt-get purge -y --auto-remove wget
 
 COPY entrypoint.sh /
 


### PR DESCRIPTION
Without the package I was getting errors like below when opening a repo with a remote set to a https URL:

    Unhandled error
    { isGitError: true,
      errorCode: 'unknown',
      command: '-c color.ui=false -c core.quotepath=false -c core.pager=cat -c credential.helper=/usr/local/lib/node_modules/ungit/bin/credentials-helper 0 8448 ls-remote --tags origin',
      workingDirectory: '/repo',
      error: 'fatal: unable to access \'https://github.com/jitakirin/docker-rpmbuild.git/\': Problem with the SSL CA cert (path? access rights?)\n',
      message: 'fatal: unable to access \'https://github.com/jitakirin/docker-rpmbuild.git/\': Problem with the SSL CA cert (path? access rights?)',
      stderr: 'fatal: unable to access \'https://github.com/jitakirin/docker-rpmbuild.git/\': Problem with the SSL CA cert (path? access rights?)\n',
      stdout: '' }